### PR TITLE
Enable configuration of OTP_STEP time for email based OTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /dist/
 /docs/build/
 *.egg-info/
+.idea/

--- a/src/django_otp/plugins/otp_email/conf.py
+++ b/src/django_otp/plugins/otp_email/conf.py
@@ -13,7 +13,8 @@ class OTPEmailSettings(object):
     """
     defaults = {
         'OTP_EMAIL_SENDER': '',
-        'OTP_EMAIL_SUBJECT': 'OTP token'
+        'OTP_EMAIL_SUBJECT': 'OTP token',
+        'OTP_STEP_TIME': 900,
     }
 
     def __init__(self):

--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -44,7 +44,7 @@ class EmailDevice(Device):
         return unhexlify(self.key.encode())
 
     def generate_challenge(self):
-        token = totp(self.bin_key)
+        token = totp(self.bin_key, step=settings.OTP_STEP_TIME)
         body = render_to_string('otp/email/token.txt', {'token': token})
 
         send_mail(settings.OTP_EMAIL_SUBJECT,
@@ -62,6 +62,6 @@ class EmailDevice(Device):
         except Exception:
             verified = False
         else:
-            verified = any(totp(self.bin_key, drift=drift) == token for drift in [0, -1])
+            verified = any(totp(self.bin_key, step=settings.OTP_STEP_TIME, drift=drift) == token for drift in [0, -1])
 
         return verified


### PR DESCRIPTION
This PR enhances django_otp.plugins.otp_email by providing support for a configurable _OTP Step Time_ by introducing OTP_STEP_TIME variable. 
