### PR TITLE
Using User.pk instead of User.id to compare users

### DIFF
--- a/src/django_otp/__init__.py
+++ b/src/django_otp/__init__.py
@@ -22,7 +22,7 @@ def login(request, device):
     """
     user = getattr(request, 'user', None)
 
-    if (user is not None) and (device is not None) and (device.user_id == user.id):
+    if (user is not None) and (device is not None) and (device.user_id == user.pk):
         request.session[DEVICE_ID_SESSION_KEY] = device.persistent_id
         request.user.otp_device = device
 

--- a/src/django_otp/forms.py
+++ b/src/django_otp/forms.py
@@ -110,7 +110,7 @@ class OTPAuthenticationFormMixin(object):
         # have the list of choices until we authenticate the user. Without the
         # following, an attacker could authenticate using some other user's OTP
         # device.
-        if (device is not None) and (device.user_id != user.id):
+        if (device is not None) and (device.user_id != user.pk):
             device = None
 
         return device

--- a/src/django_otp/middleware.py
+++ b/src/django_otp/middleware.py
@@ -44,7 +44,7 @@ class OTPMiddleware(object):
             persistent_id = request.session.get(DEVICE_ID_SESSION_KEY)
             device = self._device_from_persistent_id(persistent_id) if persistent_id else None
 
-            if (device is not None) and (device.user_id != user.id):
+            if (device is not None) and (device.user_id != user.pk):
                 device = None
 
             if (device is None) and (DEVICE_ID_SESSION_KEY in request.session):


### PR DESCRIPTION
Some projects are using custom user models, so it would be better to reference `User.pk` instead of hard coded `User.id` to improve compatibility.