### PR TITLE
update static

### DIFF
--- a/src/django_otp/admin.py
+++ b/src/django_otp/admin.py
@@ -17,9 +17,9 @@ def _admin_template_for_django_version():
     recent available.
     """
     if django.VERSION[0] >= 3:
-        return 'otp/admin19/login.html'
-    else:
         return 'otp/admin30/login.html'
+    else:
+        return 'otp/admin19/login.html'
 
 
 class OTPAdminAuthenticationForm(AdminAuthenticationForm, OTPAuthenticationFormMixin):

--- a/src/django_otp/admin.py
+++ b/src/django_otp/admin.py
@@ -13,11 +13,13 @@ def _admin_template_for_django_version():
     Returns the most appropriate Django login template available.
 
     In the past, we've had more version-specific templates. Perhaps this will
-    be true again in the future. For now, the Django 1.9 version is the most
+    be true again in the future. For now, the Django 1.9 and 3.0 version are the most
     recent available.
-
     """
-    return 'otp/admin19/login.html'
+    if django.VERSION[0] >= 3:
+        return 'otp/admin19/login.html'
+    else:
+        return 'otp/admin30/login.html'
 
 
 class OTPAdminAuthenticationForm(AdminAuthenticationForm, OTPAuthenticationFormMixin):

--- a/src/django_otp/templates/otp/admin19/login.html
+++ b/src/django_otp/templates/otp/admin19/login.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static %}
+{% load i18n static %}
 
 {% block extrastyle %}
     {{ block.super }}

--- a/src/django_otp/templates/otp/admin30/login.html
+++ b/src/django_otp/templates/otp/admin30/login.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static %}
+{% load i18n static %}
 
 {% block extrastyle %}
     {{ block.super }}


### PR DESCRIPTION
This template requires {% load i18n admin_static %} which has been removed in Django 3.0 in favor of {% load i18n static %}

https://docs.djangoproject.com/en/dev/releases/2.1/#deprecated-features-2-1