### PR TITLE
removes unsupported MIDDLEWARE_CLASSES setting

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -31,8 +31,7 @@ Basic installation has only two steps:
        usual way.
 
     #. Add :class:`django_otp.middleware.OTPMiddleware` to
-       :setting:`MIDDLEWARE` or :setting:`MIDDLEWARE_CLASSES`. It must be
-       installed *after*
+       :setting:`MIDDLEWARE`. It must be installed *after*
        :class:`~django.contrib.auth.middleware.AuthenticationMiddleware`.
 
 For example::


### PR DESCRIPTION
Changes made in 1790a69 no longer allow deprecated MIDDLEWARE_CLASSES setting.