### PR TITLE
Allow devices to use custom primary keys

### DIFF
--- a/src/django_otp/models.py
+++ b/src/django_otp/models.py
@@ -86,7 +86,7 @@ class Device(models.Model):
 
     @property
     def persistent_id(self):
-        return '{0}/{1}'.format(self.model_label(), self.id)
+        return '{0}/{1}'.format(self.model_label(), self.pk)
 
     @classmethod
     def model_label(cls):
@@ -114,7 +114,7 @@ class Device(models.Model):
 
             device_cls = apps.get_model(app_label, model_name)
             if issubclass(device_cls, Device):
-                device = device_cls.objects.filter(id=int(device_id)).first()
+                device = device_cls.objects.filter(pk=device_id).first()
         except (ValueError, LookupError):
             pass
 

--- a/src/django_otp/plugins/otp_static/tests.py
+++ b/src/django_otp/plugins/otp_static/tests.py
@@ -74,7 +74,7 @@ class AuthFormTest(TestCase):
             except IntegrityError:
                 self.skipTest("Unable to create a test user.")
             else:
-                device = user.staticdevice_set.create(id=device_id + 1)
+                device = user.staticdevice_set.create(pk=device_id + 1)
                 device.token_set.create(token=username + '1')
                 device.token_set.create(token=username + '1')
                 device.token_set.create(token=username + '2')

--- a/src/django_otp/tests.py
+++ b/src/django_otp/tests.py
@@ -76,7 +76,7 @@ class OTPMiddlewareTestCase(TestCase):
         device = self.alice.staticdevice_set.get()
         request.session = {
             DEVICE_ID_SESSION_KEY: '{}.{}/{}'.format(
-                device.__module__, device.__class__.__name__, device.id
+                device.__module__, device.__class__.__name__, device.pk
             )
         }
 


### PR DESCRIPTION
There may be instances where the primary key of a device is not an integer (such as when an app does not want an auto-incrementing integer on their devices models and instead want to use a UUID.)

Django will allow you to query using `pk=` instead of `id=` in filters, so switching to that is pretty easy.