### PR TITLE
Avoid double-wrapping user with `SimpleLazyObject`

### DIFF
--- a/src/django_otp/middleware.py
+++ b/src/django_otp/middleware.py
@@ -25,7 +25,7 @@ class OTPMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        user = getattr(request, "user", None)
+        user = getattr(request, 'user', None)
         if user is not None:
             if isinstance(user, SimpleLazyObject):
                 user._setup()

--- a/src/django_otp/middleware.py
+++ b/src/django_otp/middleware.py
@@ -25,8 +25,11 @@ class OTPMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        user = getattr(request, 'user', None)
-        if user is not None and not isinstance(user, SimpleLazyObject):
+        user = getattr(request, "user", None)
+        if user is not None:
+            if isinstance(user, SimpleLazyObject):
+                user._setup()
+                user = user._wrapped
             request.user = SimpleLazyObject(functools.partial(self._verify_user, request, user))
 
         return self.get_response(request)

--- a/src/django_otp/middleware.py
+++ b/src/django_otp/middleware.py
@@ -26,7 +26,7 @@ class OTPMiddleware:
 
     def __call__(self, request):
         user = getattr(request, 'user', None)
-        if user is not None:
+        if user is not None and not isinstance(user, SimpleLazyObject):
             request.user = SimpleLazyObject(functools.partial(self._verify_user, request, user))
 
         return self.get_response(request)


### PR DESCRIPTION
This issue occurred in combination with `graphene-django`:

```
  File "/home/circleci/project/.venv/lib/python3.8/site-packages/graphene_django/types.py", line 277, in is_type_of
    raise Exception(('Received incompatible instance "{}".').format(root))
Exception: Received incompatible instance "user1@example.com".
```

Upon a deeper dive I found that `request.user` ends up as `<SimpleLazyObject: <SimpleLazyObject: User(id=1, username='user1', email='user1@example.com')>>` after passing through `OTPMiddleware`