### PR TITLE
Fix Server Error in Admin when opening EmailDevice

### DIFF
--- a/src/django_otp/plugins/otp_email/admin.py
+++ b/src/django_otp/plugins/otp_email/admin.py
@@ -14,7 +14,7 @@ class EmailDeviceAdmin(admin.ModelAdmin):
             'fields': ['user', 'name', 'confirmed'],
         }),
         ('Configuration', {
-            'fields': ['key'],
+            'fields': ['email'],
         }),
     ]
     raw_id_fields = ['user']


### PR DESCRIPTION
The old EmailDevice 'key' field is still referenced in admin.py, instead of the new 'email' field. This causes a Server Error when an EmailDevice is opened in the Django Admin. This simple PR fixes the problem.