### PR TITLE
Fixes to the Testing Environment

### DIFF
--- a/test/test_project/settings.py
+++ b/test/test_project/settings.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'django.contrib.staticfiles',
 
     'django_otp',
     'django_otp.plugins.otp_email',
@@ -67,3 +68,7 @@ TEMPLATES = [
 SECRET_KEY = 'PWuluw4x48GkT7JDPzlDQsBJC8pjIIiqodW9MuMYcU315YEkGJL41i5qooJsg3Tt'
 
 ROOT_URLCONF = 'test_project.urls'
+
+STATIC_URL = '/static/'
+
+USE_TZ = True

--- a/test/test_project/settings.py
+++ b/test/test_project/settings.py
@@ -12,7 +12,7 @@ DEBUG = True
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
+        'NAME': project_path('db.sqlite3'),
     }
 }
 


### PR DESCRIPTION
Currently, not all tests are passing out of the box. Also, when running the test project in a browser, CSS fails to load. Small modifications to settings.py are made in order to fix both these issues.

- Configured django.contrib.staticfiles so that the Django Admin in the test project can find and load static assets (e.g. css)

- Set 'USE_TZ = True' to fix broken tests. When freezegun.freeze_time() is called without arguments, the frozen time is a naive datetime object whose value is the current date and time according to UTC. When USE_TZ is undefined or false, django.util.timezone.now() returns a naive datetime object whose value is the current date and time in the system's timezone. When the system's timezone differs from UTC, comparisons between these datetime objects and the frozen time are not sound and fail unexpectedly.