### PR TITLE
Don't rely on an id field.

### DIFF
--- a/src/django_otp/models.py
+++ b/src/django_otp/models.py
@@ -90,7 +90,7 @@ class Device(models.Model):
 
     @property
     def persistent_id(self):
-        return '{0}/{1}'.format(self.model_label(), self.id)
+        return '{0}/{1}'.format(self.model_label(), self.pk)
 
     @classmethod
     def model_label(cls):
@@ -118,7 +118,7 @@ class Device(models.Model):
 
             device_cls = apps.get_model(app_label, model_name)
             if issubclass(device_cls, Device):
-                device = device_cls.objects.filter(id=int(device_id)).first()
+                device = device_cls.objects.filter(pk=device_id).first()
         except (ValueError, LookupError):
             pass
 


### PR DESCRIPTION
There is no guarantee that a model has an `id` field.

Instead, it's better to use the `.pk`, as this is guaranteed to be present.

Likewise, it is possible to have non-integer primary key columns. 

If you do have an integer primary key, you can pass a string (that contains a valid integer), and that will query fine.