### PR TITLE
Add email template path setting

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -423,7 +423,7 @@ likely want to override.
 
 **OTP_EMAIL_BODY_TEMPLATE_PATH**
 
-Default: ``None``
+Default: ``otp/email/token.txt``
 
 A path string to a template file to use for the email body. The render context
 will include the generated token in the ``token`` key.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -415,9 +415,22 @@ Default: ``None``
 A raw template string to use for the email body. The render context will
 include the generated token in the ``token`` key.
 
-If this is not set, we'll render the template 'otp/email/token.txt', which
-you'll most likely want to override.
+If this and :setting:`OTP_EMAIL_BODY_TEMPLATE_PATH<OTP_EMAIL_TOKEN_TEMPLATE_PATH>`
+are not set, we'll render the template 'otp/email/token.txt', which you'll most
+likely want to override.
 
+.. setting:: OTP_EMAIL_TOKEN_TEMPLATE_PATH
+
+**OTP_EMAIL_BODY_TEMPLATE_PATH**
+
+Default: ``None``
+
+A path string to a template file to use for the email body. The render context
+will include the generated token in the ``token`` key.
+
+If this and :setting:`OTP_EMAIL_BODY_TEMPLATE<OTP_EMAIL_TOKEN_TEMPLATE>` are not
+set, we'll render the template 'otp/email/token.txt', which you'll most likely
+want to override.
 
 .. setting:: OTP_EMAIL_TOKEN_VALIDITY
 

--- a/src/django_otp/plugins/otp_email/conf.py
+++ b/src/django_otp/plugins/otp_email/conf.py
@@ -13,6 +13,7 @@ class OTPEmailSettings:
         'OTP_EMAIL_SENDER': None,
         'OTP_EMAIL_SUBJECT': 'OTP token',
         'OTP_EMAIL_BODY_TEMPLATE': None,
+        'OTP_EMAIL_BODY_TEMPLATE_PATH': None,
         'OTP_EMAIL_TOKEN_VALIDITY': 300,
         'OTP_EMAIL_THROTTLE_FACTOR': 1,
     }

--- a/src/django_otp/plugins/otp_email/conf.py
+++ b/src/django_otp/plugins/otp_email/conf.py
@@ -13,7 +13,7 @@ class OTPEmailSettings:
         'OTP_EMAIL_SENDER': None,
         'OTP_EMAIL_SUBJECT': 'OTP token',
         'OTP_EMAIL_BODY_TEMPLATE': None,
-        'OTP_EMAIL_BODY_TEMPLATE_PATH': None,
+        'OTP_EMAIL_BODY_TEMPLATE_PATH': 'otp/email/token.txt',
         'OTP_EMAIL_TOKEN_VALIDITY': 300,
         'OTP_EMAIL_THROTTLE_FACTOR': 1,
     }

--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -56,6 +56,8 @@ class EmailDevice(ThrottlingMixin, SideChannelDevice):
         context = {'token': self.token}
         if settings.OTP_EMAIL_BODY_TEMPLATE:
             body = Template(settings.OTP_EMAIL_BODY_TEMPLATE).render(Context(context))
+        elif settings.OTP_EMAIL_BODY_TEMPLATE_PATH:
+            body = get_template(settings.OTP_EMAIL_BODY_TEMPLATE_PATH).render(context)
         else:
             body = get_template('otp/email/token.txt').render(context)
 

--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -56,10 +56,8 @@ class EmailDevice(ThrottlingMixin, SideChannelDevice):
         context = {'token': self.token}
         if settings.OTP_EMAIL_BODY_TEMPLATE:
             body = Template(settings.OTP_EMAIL_BODY_TEMPLATE).render(Context(context))
-        elif settings.OTP_EMAIL_BODY_TEMPLATE_PATH:
-            body = get_template(settings.OTP_EMAIL_BODY_TEMPLATE_PATH).render(context)
         else:
-            body = get_template('otp/email/token.txt').render(context)
+            body = get_template(settings.OTP_EMAIL_BODY_TEMPLATE_PATH).render(context)
 
         send_mail(settings.OTP_EMAIL_SUBJECT,
                   body,

--- a/src/django_otp/plugins/otp_email/tests.py
+++ b/src/django_otp/plugins/otp_email/tests.py
@@ -113,6 +113,25 @@ class EmailTest(EmailDeviceMixin, TestCase):
         with self.subTest(field='body'):
             self.assertEqual(msg.body, "Test template 2: {}".format(self.device.token))
 
+    @override_settings(
+        OTP_EMAIL_SENDER="webmaster@example.com",
+        OTP_EMAIL_SUBJECT="Test subject",
+        OTP_EMAIL_BODY_TEMPLATE_PATH="otp/email/custom.txt",
+    )
+    def test_settings_template_path(self):
+        self.device.generate_challenge()
+
+        self.assertEqual(len(mail.outbox), 1)
+
+        msg = mail.outbox[0]
+
+        with self.subTest(field='from_email'):
+            self.assertEqual(msg.from_email, "webmaster@example.com")
+        with self.subTest(field='subject'):
+            self.assertEqual(msg.subject, "Test subject")
+        with self.subTest(field='body'):
+            self.assertEqual(msg.body, "Test template 3: {}\n".format(self.device.token))
+
     def test_alternative_email(self):
         self.device.email = 'alice2@example.com'
         self.device.save()

--- a/test/test_project/templates/otp/email/custom.txt
+++ b/test/test_project/templates/otp/email/custom.txt
@@ -1,0 +1,1 @@
+Test template 3: {{token}}


### PR DESCRIPTION
Adds the ability to use a path in the settings to a template file for
use in the email body. This will be helpful for when translations are
needed in the template or the template is sufficiently complex enough
that it would clutter the settings file.