### PR TITLE
Add settable url_config label, update tests

### DIFF
--- a/src/django_otp/plugins/otp_totp/models.py
+++ b/src/django_otp/plugins/otp_totp/models.py
@@ -126,7 +126,10 @@ class TOTPDevice(ThrottlingMixin, Device):
         The issuer is taken from :setting:`OTP_TOTP_ISSUER`, if available.
 
         """
-        label = self.user.get_username()
+        label = getattr(settings, 'OTP_TOTP_LABEL', None) or self.user.get_username()
+        if callable(label):
+            label = label(self)
+
         params = {
             'secret': b32encode(self.bin_key),
             'algorithm': 'SHA1',

--- a/src/django_otp/plugins/otp_totp/tests.py
+++ b/src/django_otp/plugins/otp_totp/tests.py
@@ -97,6 +97,32 @@ class TOTPTest(TOTPDeviceMixin, TestCase):
         self.assertIn('secret', params)
         self.assertNotIn('issuer', params)
 
+    def test_config_url_label(self):
+        with override_settings(OTP_TOTP_LABEL=None):
+            url = self.device.config_url
+
+        parsed = urlsplit(url)
+        params = parse_qs(parsed.query)
+
+        self.assertEqual(parsed.scheme, 'otpauth')
+        self.assertEqual(parsed.netloc, 'totp')
+        self.assertEqual(parsed.path, '/alice')
+        self.assertIn('secret', params)
+        self.assertNotIn('issuer', params)
+
+    def test_config_url_label_method(self):
+        with override_settings(OTP_TOTP_LABEL=lambda d: d.user.email):
+            url = self.device.config_url
+
+        parsed = urlsplit(url)
+        params = parse_qs(parsed.query)
+
+        self.assertEqual(parsed.scheme, 'otpauth')
+        self.assertEqual(parsed.netloc, 'totp')
+        self.assertEqual(parsed.path, '/alice%40example.com')
+        self.assertIn('secret', params)
+        self.assertNotIn('issuer', params)
+
     def test_config_url_issuer(self):
         with override_settings(OTP_TOTP_ISSUER='example.com'):
             url = self.device.config_url


### PR DESCRIPTION
This pull-request aim to provide a user customizable [**label**] parameter for the TOTPDevice model config_url property.