### PR TITLE
Casting label to string in config_url

### DIFF
--- a/src/django_otp/plugins/otp_totp/models.py
+++ b/src/django_otp/plugins/otp_totp/models.py
@@ -126,7 +126,7 @@ class TOTPDevice(ThrottlingMixin, Device):
         The issuer is taken from :setting:`OTP_TOTP_ISSUER`, if available.
 
         """
-        label = self.user.get_username()
+        label = str(self.user.get_username())
         params = {
             'secret': b32encode(self.bin_key),
             'algorithm': 'SHA1',


### PR DESCRIPTION
Hi, here is a proposed fix to make sure quote method in urllib receives a string. Related to [#77 ](https://github.com/django-otp/django-otp/issues/77)