### PR TITLE
Add ability to pass extra context when rendering email templates

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -415,6 +415,9 @@ Default: ``None``
 A raw template string to use for the email body. The render context will
 include the generated token in the ``token`` key.
 
+Dictionary sent to :meth:`~django_otp.plugins.otp_email.models.EmailDevice.generate_challenge`
+under ``extra_context`` will be also used as context for building the email.
+
 If this and :setting:`OTP_EMAIL_BODY_TEMPLATE_PATH` are not set, we'll render
 the template 'otp/email/token.txt', which you'll most likely want to override.
 
@@ -427,6 +430,9 @@ Default: ``otp/email/token.txt``
 
 A path string to a template file to use for the email body. The render context
 will include the generated token in the ``token`` key.
+
+Dictionary sent to :meth:`~django_otp.plugins.otp_email.models.EmailDevice.generate_challenge`
+under ``extra_context`` will be also used as context for building the email.
 
 If this and :setting:`OTP_EMAIL_BODY_TEMPLATE` are not set, we'll render the
 template 'otp/email/token.txt', which you'll most likely want to override.

--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -50,6 +50,10 @@ class EmailDevice(ThrottlingMixin, SideChannelDevice):
     def generate_challenge(self, extra_context=None):
         """
         Generates a random token and emails it to the user.
+
+        :param extra_context: If provided, the dictionary will be used as context,
+            along with the token, for generating the email. Default is ``None``.
+        :type extra_context: dict
         """
         self.generate_token(valid_secs=settings.OTP_EMAIL_TOKEN_VALIDITY)
 

--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -47,13 +47,13 @@ class EmailDevice(ThrottlingMixin, SideChannelDevice):
     def get_throttle_factor(self):
         return settings.OTP_EMAIL_THROTTLE_FACTOR
 
-    def generate_challenge(self):
+    def generate_challenge(self, extra_context=None):
         """
         Generates a random token and emails it to the user.
         """
         self.generate_token(valid_secs=settings.OTP_EMAIL_TOKEN_VALIDITY)
 
-        context = {'token': self.token}
+        context = {'token': self.token, **(extra_context or {})}
         if settings.OTP_EMAIL_BODY_TEMPLATE:
             body = Template(settings.OTP_EMAIL_BODY_TEMPLATE).render(Context(context))
         else:


### PR DESCRIPTION
It would be really useful to be able to send extra context when building the email, that way we can have our custom email template with more things other than the token