### PR TITLE
User username from view context

### DIFF
--- a/src/django_otp/templates/otp/admin111/login.html
+++ b/src/django_otp/templates/otp/admin111/login.html
@@ -51,7 +51,7 @@
 
 {% if user.is_authenticated %}
 <p class="errornote">
-{% blocktrans with username=request.user.username trimmed %}
+{% blocktrans trimmed %}
     You are authenticated as {{ username }}, but are not authorized to
     access this page. Would you like to login to a different account?
 {% endblocktrans %}


### PR DESCRIPTION
Not all Django user models have a `username` field (e.g. some models use `email` as a username).

Use the `username` context variable instead.

The `username` context variable has been available in the login view since (at least) Django 1.9 (https://github.com/django/django/blob/stable/1.9.x/django/contrib/admin/sites.py#L401) up to and including the current development version: https://github.com/django/django/blob/main/django/contrib/admin/sites.py#L404