### PR TITLE
Force OTP_EMAIL_SUBJECT to be a string

### DIFF
--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -64,7 +64,7 @@ class EmailDevice(ThrottlingMixin, SideChannelDevice):
         else:
             body = get_template(settings.OTP_EMAIL_BODY_TEMPLATE_PATH).render(context)
 
-        send_mail(settings.OTP_EMAIL_SUBJECT,
+        send_mail(str(settings.OTP_EMAIL_SUBJECT),
                   body,
                   settings.OTP_EMAIL_SENDER,
                   [self.email or self.user.email])


### PR DESCRIPTION
If OTP_EMAIL_SUBJECT is a lazy string (translatable), some e-mail back-ends such as SendGrid will will crash when trying to serialize it for API request with the following error: "Object of type __proxy__ is not JSON serializable"

This commit forces the subject to be a string instance.