### PR TITLE
Support override for send_mail

### DIFF
--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -99,6 +99,13 @@ class EmailDevice(TimestampMixin, CooldownMixin, ThrottlingMixin, SideChannelDev
         else:
             body_html = None
 
+        self._send_mail(body, body_html)
+
+        message = "sent by email"
+
+        return message
+
+    def _send_mail(self, body, body_html):
         send_mail(
             str(settings.OTP_EMAIL_SUBJECT),
             body,
@@ -106,10 +113,6 @@ class EmailDevice(TimestampMixin, CooldownMixin, ThrottlingMixin, SideChannelDev
             [self.email or self.user.email],
             html_message=body_html,
         )
-
-        message = "sent by email"
-
-        return message
 
     def verify_token(self, token):
         """"""


### PR DESCRIPTION
Hello :)

In our implementation, we need to customize the subject and from based [on the current site](https://docs.djangoproject.com/en/5.0/ref/contrib/sites/) 

Doint this refactor, allow us to override the _send_mail :) 