### PR TITLE
Add support for `segno` as alternative to `qrcode` for QR image generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+Pending
+--------------------------------------------------------------------------------
+
+- `#141`_: Support alternative QR code library `segno`_.
+
+  Previously, only the `qrcode`_ library was supported.
+
+  Use ``segno`` by installing ``django-otp[segno]`` or just install the
+  ``segno`` package.
+
+.. _#141: https://github.com/django-otp/django-otp/issues/141
+.. _segno: https://pypi.python.org/pypi/segno/
+
 v1.4.1 - April 10, 2024 - Minor EmailDevice updates
 --------------------------------------------------------------------------------
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -211,12 +211,13 @@ django-otp includes support for several standard device types.
 :class:`~django_otp.plugins.otp_totp.models.TOTPDevice` handle standard OTP
 algorithms, which can be used with a variety of OTP generators. For example,
 it's easy to pair these devices with `Google Authenticator`_ using the `otpauth
-URL scheme`_. If you have the `qrcode`_ package installed, the admin interface
-will generate QR Codes for you.
+URL scheme`_. If you have either the `segno`_ or `qrcode`_ packages installed,
+the admin interface will generate QR Codes for you.
 
 
 .. _Google Authenticator: https://github.com/google/google-authenticator
 .. _otpauth URL scheme: https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+.. _segno: https://pypi.python.org/pypi/segno/
 .. _qrcode: https://pypi.python.org/pypi/qrcode/
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+segno = [
+    "segno",
+]
 qrcode = [
     "qrcode",
 ]
@@ -38,6 +41,7 @@ Documentation = "https://django-otp-official.readthedocs.io/"
 
 [tool.hatch.envs.default]
 features = [
+    "segno",
     "qrcode",
 ]
 dependencies = [

--- a/src/django_otp/plugins/otp_hotp/admin.py
+++ b/src/django_otp/plugins/otp_hotp/admin.py
@@ -7,6 +7,7 @@ from django.urls import path, reverse
 from django.utils.html import format_html
 
 from django_otp.conf import settings
+from django_otp.qr import write_qrcode_image
 
 from .models import HOTPDevice
 
@@ -150,15 +151,9 @@ class HOTPDeviceAdmin(admin.ModelAdmin):
             raise PermissionDenied()
 
         try:
-            import qrcode
-            import qrcode.image.svg
-
-            img = qrcode.make(
-                device.config_url, image_factory=qrcode.image.svg.SvgImage
-            )
             response = HttpResponse(content_type='image/svg+xml')
-            img.save(response)
-        except ImportError:
+            write_qrcode_image(device.config_url, response)
+        except ModuleNotFoundError:
             response = HttpResponse('', status=503)
 
         return response

--- a/src/django_otp/plugins/otp_hotp/templates/otp_hotp/admin/config.html
+++ b/src/django_otp/plugins/otp_hotp/templates/otp_hotp/admin/config.html
@@ -10,7 +10,7 @@
     >
   </p>
   <p id="no-qrcode" style="display: none">
-    Install <a href="https://pypi.python.org/pypi/qrcode/">qrcode</a> or use the URL below:
+    Install <a href="https://pypi.python.org/pypi/segno/">segno</a> or <a href="https://pypi.python.org/pypi/qrcode/">qrcode</a> or use the URL below:
   </p>
   <p>{{ device.config_url }}</p>
 </div>

--- a/src/django_otp/plugins/otp_totp/admin.py
+++ b/src/django_otp/plugins/otp_totp/admin.py
@@ -7,6 +7,7 @@ from django.urls import path, reverse
 from django.utils.html import format_html
 
 from django_otp.conf import settings
+from django_otp.qr import write_qrcode_image
 
 from .models import TOTPDevice
 
@@ -150,15 +151,9 @@ class TOTPDeviceAdmin(admin.ModelAdmin):
             raise PermissionDenied()
 
         try:
-            import qrcode
-            import qrcode.image.svg
-
-            img = qrcode.make(
-                device.config_url, image_factory=qrcode.image.svg.SvgImage
-            )
             response = HttpResponse(content_type='image/svg+xml')
-            img.save(response)
-        except ImportError:
+            write_qrcode_image(device.config_url, response)
+        except ModuleNotFoundError:
             response = HttpResponse('', status=503)
 
         return response

--- a/src/django_otp/plugins/otp_totp/templates/otp_totp/admin/config.html
+++ b/src/django_otp/plugins/otp_totp/templates/otp_totp/admin/config.html
@@ -10,7 +10,7 @@
     >
   </p>
   <p id="no-qrcode" style="display: none">
-    Install <a href="https://pypi.python.org/pypi/qrcode/">qrcode</a> or use the URL below:
+    Install <a href="https://pypi.python.org/pypi/segno/">segno</a> or <a href="https://pypi.python.org/pypi/qrcode/">qrcode</a> or use the URL below:
   </p>
   <p>{{ device.config_url }}</p>
 </div>

--- a/src/django_otp/qr.py
+++ b/src/django_otp/qr.py
@@ -1,0 +1,19 @@
+def write_qrcode_image(data, out):
+    """Write a QR code image for data to out.
+
+    The written image is in image/svg+xml format.
+
+    One of `qrcode` or `segno` are required. If neither is found, raises
+    ModuleNotFoundError.
+    """
+    try:
+        import qrcode
+        import qrcode.image.svg
+
+        img = qrcode.make(data, image_factory=qrcode.image.svg.SvgImage)
+        img.save(out)
+    except ModuleNotFoundError:
+        import segno
+
+        img = segno.make(data)
+        img.save(out, kind='svg')


### PR DESCRIPTION
Fix #141.

If both qrcode and segno are installed, I give qrcode priority for backward compatibility. But in other places I mention segno first because I do think it's preferable.

I verified that the qrcode is shown correctly in all 3 cases (qrcode, segno, both).