### PR TITLE
Added search ability in admin using username and email

### DIFF
--- a/src/django_otp/admin.py
+++ b/src/django_otp/admin.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.contrib.admin.forms import AdminAuthenticationForm
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.core.exceptions import FieldDoesNotExist
 
 from .forms import OTPAuthenticationFormMixin
 
@@ -14,6 +16,45 @@ def _admin_template_for_django_version():
     even with the most recent Django version.
     """
     return 'otp/admin111/login.html'
+
+
+def user_model_search_fields(field_names):
+    """
+    Check whether the provided field names exist, and return a tuple of
+    search fields and help text for the validated field names.
+
+    Parameters:
+    field_names (list of str): A list of field names to search for in the user model.
+
+    Returns:
+    tuple: A tuple containing:
+        - search_fields (list of str): A list of search fields formatted for querying.
+        - search_help_text (str): A help text string describing the valid search fields.
+    """
+    User = get_user_model()
+    valid_fields = []
+    search_fields = []
+    help_texts = []
+
+    for name in field_names:
+        try:
+            field = User._meta.get_field(name)
+        except FieldDoesNotExist:
+            continue
+        else:
+            valid_fields.append(field)
+            search_fields.append("user__" + field.name)
+            help_texts.append(str(field.verbose_name))
+
+    # Join terms with commas, except use "or" before the last term
+
+    search_help_text = (
+        "Search by " + ", ".join(help_texts[:-1]) + f" or {help_texts[-1]}"
+        if help_texts
+        else ""
+    )
+
+    return search_fields, search_help_text
 
 
 class OTPAdminAuthenticationForm(AdminAuthenticationForm, OTPAuthenticationFormMixin):

--- a/src/django_otp/admin.py
+++ b/src/django_otp/admin.py
@@ -46,13 +46,15 @@ def user_model_search_fields(field_names):
             search_fields.append("user__" + field.name)
             help_texts.append(str(field.verbose_name))
 
-    # Join terms with commas, except use "or" before the last term
+    if len(help_texts) == 0:
+        search_help_text = ""
+    else:
+        search_help_text = "Search by user's "
 
-    search_help_text = (
-        "Search by " + ", ".join(help_texts[:-1]) + f" or {help_texts[-1]}"
-        if help_texts
-        else ""
-    )
+        if len(help_texts) == 1:
+            search_help_text += help_texts[0]
+        else:
+            search_help_text += ", ".join(help_texts[:-1]) + f" or {help_texts[-1]}"
 
     return search_fields, search_help_text
 

--- a/src/django_otp/plugins/otp_email/admin.py
+++ b/src/django_otp/plugins/otp_email/admin.py
@@ -1,5 +1,8 @@
 from django.contrib import admin
 from django.contrib.admin.sites import AlreadyRegistered
+from django.contrib.auth import get_user_model
+
+from django_otp.admin import user_model_search_fields
 
 from .models import EmailDevice
 
@@ -10,8 +13,12 @@ class EmailDeviceAdmin(admin.ModelAdmin):
     :class:`~django_otp.plugins.otp_email.models.EmailDevice`.
     """
 
+    User = get_user_model()
+    candidate_search_field = [User.USERNAME_FIELD, 'email']
+
     list_display = ['user', 'name', 'created_at', 'last_used_at', 'confirmed']
     list_filter = ['created_at', 'last_used_at', 'confirmed']
+    search_fields, search_help_text = user_model_search_fields(candidate_search_field)
 
     raw_id_fields = ['user']
     readonly_fields = ['created_at', 'last_used_at']

--- a/src/django_otp/plugins/otp_hotp/admin.py
+++ b/src/django_otp/plugins/otp_hotp/admin.py
@@ -1,11 +1,13 @@
 from django.contrib import admin
 from django.contrib.admin.sites import AlreadyRegistered
+from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.html import format_html
 
+from django_otp.admin import user_model_search_fields
 from django_otp.conf import settings
 from django_otp.qr import write_qrcode_image
 
@@ -18,8 +20,12 @@ class HOTPDeviceAdmin(admin.ModelAdmin):
     :class:`~django_otp.plugins.otp_hotp.models.HOTPDevice`.
     """
 
+    User = get_user_model()
+    candidate_search_field = [User.USERNAME_FIELD, 'email']
+
     list_display = ['user', 'name', 'created_at', 'last_used_at', 'confirmed']
     list_filter = ['created_at', 'last_used_at', 'confirmed']
+    search_fields, search_help_text = user_model_search_fields(candidate_search_field)
 
     raw_id_fields = ['user']
     readonly_fields = ['created_at', 'last_used_at', 'qrcode_link']

--- a/src/django_otp/plugins/otp_static/admin.py
+++ b/src/django_otp/plugins/otp_static/admin.py
@@ -1,6 +1,8 @@
 from django.contrib import admin
 from django.contrib.admin.sites import AlreadyRegistered
+from django.contrib.auth import get_user_model
 
+from django_otp.admin import user_model_search_fields
 from django_otp.conf import settings
 
 from .models import StaticDevice, StaticToken
@@ -17,8 +19,12 @@ class StaticDeviceAdmin(admin.ModelAdmin):
     :class:`~django_otp.plugins.otp_static.models.StaticDevice`.
     """
 
+    User = get_user_model()
+    candidate_search_field = [User.USERNAME_FIELD, 'email']
+
     list_display = ['user', 'name', 'created_at', 'last_used_at', 'confirmed']
     list_filter = ['created_at', 'last_used_at', 'confirmed']
+    search_fields, search_help_text = user_model_search_fields(candidate_search_field)
 
     raw_id_fields = ['user']
     readonly_fields = ['created_at', 'last_used_at']

--- a/src/django_otp/plugins/otp_totp/admin.py
+++ b/src/django_otp/plugins/otp_totp/admin.py
@@ -1,11 +1,13 @@
 from django.contrib import admin
 from django.contrib.admin.sites import AlreadyRegistered
+from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.html import format_html
 
+from django_otp.admin import user_model_search_fields
 from django_otp.conf import settings
 from django_otp.qr import write_qrcode_image
 
@@ -18,8 +20,12 @@ class TOTPDeviceAdmin(admin.ModelAdmin):
     :class:`~django_otp.plugins.otp_totp.models.TOTPDevice`.
     """
 
+    User = get_user_model()
+    candidate_search_field = [User.USERNAME_FIELD, 'email']
+
     list_display = ['user', 'name', 'created_at', 'last_used_at', 'confirmed']
     list_filter = ['created_at', 'last_used_at', 'confirmed']
+    search_fields, search_help_text = user_model_search_fields(candidate_search_field)
 
     raw_id_fields = ['user']
     readonly_fields = ['created_at', 'last_used_at', 'qrcode_link']


### PR DESCRIPTION
The proposed changes will allow searching tokens by the associated user's username or email. This is closely related to #114 which I noticed did not receive any updates.

As per the standard approach, we use `search_fields` to define which fields we want to be included in the search. However, since the User model can be customized to some extend, `user_model_search_fields` function was added to check that fields exist before adding the to the `search_fields`. 

Note: A [similar approach](https://github.com/pennersr/django-allauth/blob/c76e9fbd3b03e16d272a9f0d0f69ba762e03812a/allauth/account/adapter.py#L542) is used in django-allauth 

Further, the function constructs the help text for the search field.

The search functionality was applied to all four plugins.