### PR TITLE
Remove JS focus() in admin login template

### DIFF
--- a/src/django_otp/templates/otp/admin111/login.html
+++ b/src/django_otp/templates/otp/admin111/login.html
@@ -91,9 +91,5 @@
     {% endif %}
   </div>
 </form>
-
-<script type="text/javascript">
-document.getElementById('id_username').focus()
-</script>
 </div>
 {% endblock %}


### PR DESCRIPTION
Modern Django is setting autofocus attribute on the username in the AuthenticationForm, so no need to extra JS.