### PR TITLE
Pre Django 3.2 Cleaning

### DIFF
--- a/src/django_otp/plugins/otp_email/__init__.py
+++ b/src/django_otp/plugins/otp_email/__init__.py
@@ -1,4 +1,0 @@
-import django
-
-if django.VERSION < (3, 2):
-    default_app_config = 'django_otp.plugins.otp_email.apps.DefaultConfig'

--- a/src/django_otp/plugins/otp_hotp/__init__.py
+++ b/src/django_otp/plugins/otp_hotp/__init__.py
@@ -1,4 +1,0 @@
-import django
-
-if django.VERSION < (3, 2):
-    default_app_config = 'django_otp.plugins.otp_hotp.apps.DefaultConfig'

--- a/src/django_otp/plugins/otp_hotp/admin.py
+++ b/src/django_otp/plugins/otp_hotp/admin.py
@@ -102,6 +102,7 @@ class HOTPDeviceAdmin(admin.ModelAdmin):
     # Columns
     #
 
+    @admin.display(description="QR Code")
     def qrcode_link(self, device):
         try:
             href = reverse('admin:otp_hotp_hotpdevice_config', kwargs={'pk': device.pk})
@@ -110,8 +111,6 @@ class HOTPDeviceAdmin(admin.ModelAdmin):
             link = ''
 
         return link
-
-    qrcode_link.short_description = "QR Code"
 
     #
     # Custom views

--- a/src/django_otp/plugins/otp_static/__init__.py
+++ b/src/django_otp/plugins/otp_static/__init__.py
@@ -1,4 +1,0 @@
-import django
-
-if django.VERSION < (3, 2):
-    default_app_config = 'django_otp.plugins.otp_static.apps.DefaultConfig'

--- a/src/django_otp/plugins/otp_totp/__init__.py
+++ b/src/django_otp/plugins/otp_totp/__init__.py
@@ -1,4 +1,0 @@
-import django
-
-if django.VERSION < (3, 2):
-    default_app_config = 'django_otp.plugins.otp_totp.apps.DefaultConfig'

--- a/src/django_otp/plugins/otp_totp/admin.py
+++ b/src/django_otp/plugins/otp_totp/admin.py
@@ -102,6 +102,7 @@ class TOTPDeviceAdmin(admin.ModelAdmin):
     # Columns
     #
 
+    @admin.display(description="QR Code")
     def qrcode_link(self, device):
         try:
             href = reverse('admin:otp_totp_totpdevice_config', kwargs={'pk': device.pk})
@@ -110,8 +111,6 @@ class TOTPDeviceAdmin(admin.ModelAdmin):
             link = ''
 
         return link
-
-    qrcode_link.short_description = "QR Code"
 
     #
     # Custom views


### PR DESCRIPTION
Safer and smaller version of https://github.com/django-otp/django-otp/pull/168

Clean Django < 3.2 residues without changing dependency versions.