### PR TITLE
adding {token} option for email subject

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -417,6 +417,7 @@ will automatically use :setting:`DEFAULT_FROM_EMAIL`.
 Default: ``'OTP token'``
 
 The subject of the email. You probably want to customize this.
+A ``{{token}}`` placeholder is available for the generated token.
 
 
 .. setting:: OTP_EMAIL_BODY_TEMPLATE

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -417,7 +417,7 @@ will automatically use :setting:`DEFAULT_FROM_EMAIL`.
 Default: ``'OTP token'``
 
 The subject of the email. You probably want to customize this.
-A ``{{token}}`` placeholder is available for the generated token.
+A ``{token}`` placeholder is available for the generated token.
 
 
 .. setting:: OTP_EMAIL_BODY_TEMPLATE

--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -100,7 +100,9 @@ class EmailDevice(TimestampMixin, CooldownMixin, ThrottlingMixin, SideChannelDev
         else:
             body_html = None
 
-        self.send_mail(body, html_message=body_html)
+        subject = str(settings.OTP_EMAIL_SUBJECT).format(token=self.token)
+
+        self.send_mail(body, html_message=body_html, subject=subject)
 
         message = gettext("sent by email")
 
@@ -113,8 +115,11 @@ class EmailDevice(TimestampMixin, CooldownMixin, ThrottlingMixin, SideChannelDev
         Subclasses (e.g. proxy models) may override this to customize delivery.
 
         """
-        subject = str(settings.OTP_EMAIL_SUBJECT).format(token=self.token)
 
+        subject = kwargs.pop('subject', None)
+        if not subject:
+            subject = str(settings.OTP_EMAIL_SUBJECT)
+        
         send_mail(
             subject,
             body,

--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -119,7 +119,7 @@ class EmailDevice(TimestampMixin, CooldownMixin, ThrottlingMixin, SideChannelDev
         subject = kwargs.pop('subject', None)
         if not subject:
             subject = str(settings.OTP_EMAIL_SUBJECT)
-        
+
         send_mail(
             subject,
             body,

--- a/src/django_otp/plugins/otp_email/models.py
+++ b/src/django_otp/plugins/otp_email/models.py
@@ -113,8 +113,10 @@ class EmailDevice(TimestampMixin, CooldownMixin, ThrottlingMixin, SideChannelDev
         Subclasses (e.g. proxy models) may override this to customize delivery.
 
         """
+        subject = str(settings.OTP_EMAIL_SUBJECT).format(token=self.token)
+
         send_mail(
-            str(settings.OTP_EMAIL_SUBJECT),
+            subject,
             body,
             settings.OTP_EMAIL_SENDER,
             [self.email or self.user.email],

--- a/src/django_otp/plugins/otp_email/tests.py
+++ b/src/django_otp/plugins/otp_email/tests.py
@@ -100,6 +100,7 @@ class EmailTest(EmailDeviceMixin, TestCase):
             self.assertEqual(
                 msg.body, "Test template 1: {}\n".format(self.device.token)
             )
+
     @override_settings(
         OTP_EMAIL_SENDER="webmaster@example.com",
         OTP_EMAIL_SUBJECT="Test Subject with token: {token}",

--- a/src/django_otp/plugins/otp_email/tests.py
+++ b/src/django_otp/plugins/otp_email/tests.py
@@ -116,7 +116,9 @@ class EmailTest(EmailDeviceMixin, TestCase):
         with self.subTest(field='from_email'):
             self.assertEqual(msg.from_email, "webmaster@example.com")
         with self.subTest(field='subject'):
-            self.assertEqual(msg.subject, "Test Subject with token: {}".format(self.device.token))
+            self.assertEqual(
+                msg.subject, "Test Subject with token: {}".format(self.device.token)
+            )
         with self.subTest(field='body'):
             self.assertEqual(msg.body, "Test template: {}".format(self.device.token))
 

--- a/src/django_otp/plugins/otp_email/tests.py
+++ b/src/django_otp/plugins/otp_email/tests.py
@@ -100,6 +100,24 @@ class EmailTest(EmailDeviceMixin, TestCase):
             self.assertEqual(
                 msg.body, "Test template 1: {}\n".format(self.device.token)
             )
+    @override_settings(
+        OTP_EMAIL_SENDER="webmaster@example.com",
+        OTP_EMAIL_SUBJECT="Test Subject with token: {token}",
+        OTP_EMAIL_BODY_TEMPLATE="Test template: {token}",
+    )
+    def test_settings_with_token_in_subject(self):
+        self.device.generate_challenge()
+
+        self.assertEqual(len(mail.outbox), 1)
+
+        msg = mail.outbox[0]
+
+        with self.subTest(field='from_email'):
+            self.assertEqual(msg.from_email, "webmaster@example.com")
+        with self.subTest(field='subject'):
+            self.assertEqual(msg.subject, "Test Subject with token: {}".format(self.device.token))
+        with self.subTest(field='body'):
+            self.assertEqual(msg.body, "Test template: {}".format(self.device.token))
 
     @override_settings(
         OTP_EMAIL_SENDER="webmaster@example.com",

--- a/src/django_otp/plugins/otp_email/tests.py
+++ b/src/django_otp/plugins/otp_email/tests.py
@@ -104,7 +104,7 @@ class EmailTest(EmailDeviceMixin, TestCase):
     @override_settings(
         OTP_EMAIL_SENDER="webmaster@example.com",
         OTP_EMAIL_SUBJECT="Test Subject with token: {token}",
-        OTP_EMAIL_BODY_TEMPLATE="Test template: {token}",
+        OTP_EMAIL_BODY_TEMPLATE="Test template: {{token}}",
     )
     def test_settings_with_token_in_subject(self):
         self.device.generate_challenge()


### PR DESCRIPTION
Adding an option to specify {token} in the email subject as it's very convenient to receive the token in the subject - especially on mobile devices as a push notification without switching apps to the email client.