### PR TITLE
Removes tests from wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,8 @@ include = [
     "/CHANGES.rst",
     "/CONTRIBUTING.rst",
 ]
+
+
 #
 # Other tools
 #


### PR DESCRIPTION
Tests should not be in the final distribution of the package

When running `hatch build` and then 
`tar -tzf  dist/django_otp-1.6.1.tar.gz`
`unzip -l dist/django_otp-1.6.1-py3-none-any.whl`

the tests should not show.